### PR TITLE
Designer fixes for (#4)

### DIFF
--- a/TZStackView.nuspec
+++ b/TZStackView.nuspec
@@ -4,8 +4,4 @@
     <id>TZStackView</id>
     <description>UIStackView backport for iOS 7 and 8 for Xamarin.iOS</description>
   </metadata>
-  <files>   
-    <file src="TZStackView\**\*.cs" target="src\TZStackView" />
-	  <file src="Sample\**\*.cs" target="src\Sample" />
-  </files>
 </package>

--- a/TZStackView.sln
+++ b/TZStackView.sln
@@ -9,9 +9,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample", "Sample\Sample.csp
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{EE34CC8E-4EF8-4C74-922A-4E6B1113F70D}"
 	ProjectSection(SolutionItems) = preProject
-		pack.bat = pack.bat
 		README.md = README.md
 		TZStackView.nuspec = TZStackView.nuspec
+		build.cake = build.cake
 	EndProjectSection
 EndProject
 Global

--- a/TZStackView/Alignment.cs
+++ b/TZStackView/Alignment.cs
@@ -1,13 +1,50 @@
 ﻿namespace TZStackView
 {
-    public enum Alignment : byte
+    /// <summary>
+    /// Alignment, the layout transverse to the stacking axis.
+    /// </summary>
+    public enum Alignment
     {
-        Fill = 1,
-        Center = 1 << 1,
-        Leading = 1 << 2,
-        Top = 1 << 3,
-        Trailing = 1 << 4,
-        Bottom = 1 << 5,
-        FirstBaseline = 1 << 6
+        /// <summary>
+        /// Align the leading and trailing edges of vertically stacked items
+        /// or the top and bottom edges of horizontally stacked items tightly to the container.
+        /// </summary>
+        Fill = 0,
+
+        /// <summary>
+        /// Align the leading edges of vertically stacked items
+        /// or the top edges of horizontally stacked items tightly to the relevant edge
+        /// of the container.
+        /// </summary>
+        Leading = 1,
+
+        /// <summary>
+        /// Align the leading edges of vertically stacked items
+        /// or the top edges of horizontally stacked items tightly to the relevant edge
+        /// of the container.
+        /// </summary>
+        Top = Leading,
+
+        FirstBaseline = 2,
+
+        /// <summary>
+        /// Center the items in a vertical stack horizontally
+        /// or the items in a horizontal stack vertically
+        /// </summary>
+        Center = 3,
+
+        /// <summary>
+        /// Align the trailing edges of vertically stacked items
+        /// or the bottom edges of horizontally stacked items tightly to the relevant
+        /// edge of the container
+        /// </summary>
+        Trailing = 4,
+
+        /// <summary>
+        /// Align the trailing edges of vertically stacked items
+        /// or the bottom edges of horizontally stacked items tightly to the relevant
+        /// edge of the container
+        /// </summary>
+        Bottom = Trailing
     }
 }

--- a/TZStackView/Distribution.cs
+++ b/TZStackView/Distribution.cs
@@ -1,11 +1,51 @@
 ﻿namespace TZStackView
 {
-    public enum Distribution : byte
+    /// <summary>
+    /// Distribution. The layout along the stacking axis.
+    /// All <see cref="UIKit.UIStackViewDistribution"> enum values fit first and last 
+    /// arranged subviews tightly to the container, except for 
+    /// <see cref="UIKit.UIStackViewDistribution.FillEqually"/>, fit all items to 
+    /// <see cref="UIKit.UIView.IntrinsicContentSize"/> when possible.
+    /// </summary>
+    public enum Distribution
     {
-        Fill = 1,
-        FillEqualy = 1 << 1,
-        FillProportionally = 1 << 2,
-        EqualSpacing = 1 << 3,
-        EqualCentering = 1 << 4
+        /// <summary>
+        /// When items do not fit (overflow) or fill (underflow) the space available
+        /// adjustments occur according to CompressionResistance or hugging
+        /// priorities of items, or when that is ambiguous, according to arrangement order.
+        /// </summary>
+        Fill = 0,
+
+        /// <summary>
+        /// Items are all the same size.
+        /// When space allows, this will be the size of the item with the largest
+        /// <see cref="UIKit.UIView.IntrinsicContentSize"/> (along the axis of the stack).
+        /// Overflow or underflow adjustments are distributed equally among the items.
+        /// </summary>
+        FillEqualy = 1,
+
+        /// <summary>
+        /// Overflow or underflow adjustments are distributed among the items proportional
+        /// to their <see cref="UIKit.UIView.IntrinsicContentSize"/>.
+        /// </summary>
+        FillProportionally = 2,
+
+        /// <summary>
+        /// Additional underflow spacing is divided equally in the spaces between the items.
+        /// Overflow squeezing is controlled by compressionResistance priorities followed by
+        /// arrangement order.
+        /// </summary>
+        EqualSpacing = 3,
+
+        /// <summary>
+        /// Equal center-to-center spacing of the items is maintained as much
+        /// as possible while still maintaining a minimum edge-to-edge spacing within the
+        /// allowed area.
+        /// Additional underflow spacing is divided equally in the spacing. Overflow
+        /// squeezing is distributed first according to CompressionResistance priorities
+        /// of items, then according to subview order while maintaining the configured
+        /// (edge-to-edge) spacing as a minimum.
+        /// </summary>
+        EqualCentering = 4
     }
 }

--- a/TZStackView/StackView.cs
+++ b/TZStackView/StackView.cs
@@ -15,17 +15,19 @@ namespace TZStackView
     [DesignTimeVisible(true)]
     public class StackView : UIView
     {
-        private readonly ObservableCollection<UIView> _arrangedSubviews = new ObservableCollection<UIView>();
+        private readonly ObservableCollection<UIView> _arrangedSubviews =
+            new ObservableCollection<UIView>();
         private readonly List<UIView> _registeredHiddenObserverViews = new List<UIView>();
         private readonly List<UIView> _animatingToHiddenViews = new List<UIView>();
         private readonly List<UIView> _spacerViews = new List<UIView>();
-        private readonly List<NSLayoutConstraint> _stackViewConstraints = new List<NSLayoutConstraint>();
-        private readonly List<NSLayoutConstraint> _subviewConstraints = new List<NSLayoutConstraint>();
+        private readonly List<NSLayoutConstraint> _stackViewConstraints =
+            new List<NSLayoutConstraint>();
+        private readonly List<NSLayoutConstraint> _subviewConstraints =
+            new List<NSLayoutConstraint>();
         private Alignment _alignment = Alignment.Fill;
         private Distribution _distribution = Distribution.Fill;
         private UILayoutConstraintAxis _axis = UILayoutConstraintAxis.Horizontal;
 
-        [Export("Disribution"), Browsable(true)]
         public Distribution Distribution
         {
             get { return _distribution; }
@@ -36,7 +38,13 @@ namespace TZStackView
             }
         }
 
-        [Export("Alignment"), Browsable(true)]
+        [Export("Disribution"), Browsable(true)]
+        public int DistributionValue
+        {
+            get { return (int)Distribution; }
+            set { Distribution = (Distribution)value; }
+        }
+
         public Alignment Alignment
         {
             get { return _alignment; }
@@ -47,7 +55,13 @@ namespace TZStackView
             }
         }
 
-        [Export("Axis"), Browsable(true)]
+        [Export("Alignment"), Browsable(true)]
+        public int AlignmentValue
+        {
+            get { return (int)Alignment; }
+            set { Alignment = (Alignment)value; }
+        }
+
         public UILayoutConstraintAxis Axis
         {
             get { return _axis; }
@@ -56,6 +70,13 @@ namespace TZStackView
                 _axis = value;
                 SetNeedsUpdateConstraints();
             }
+        }
+
+        [Export("Axis"), Browsable(true)]
+        public int AxisValue
+        {
+            get { return (int)Axis; }
+            set { Axis = (UILayoutConstraintAxis)value; }
         }
 
         public IEnumerable<UIView> ArrangedSubviews => _arrangedSubviews;
@@ -82,16 +103,40 @@ namespace TZStackView
 
         public StackView(IntPtr handle) : base(handle) { }
 
-        public StackView(IEnumerable<UIView> arrangedSubviews = null) 
+        public StackView(IEnumerable<UIView> arrangedSubviews = null)
             : base(CGRect.Empty)
         {
-			_arrangedSubviews.CollectionChanged += ArrangedSubviewsChanged;
+            _arrangedSubviews.CollectionChanged += ArrangedSubviewsChanged;
             Initialize(arrangedSubviews);
+        }
+
+        public StackView(CGRect frame)
+            : base(frame)
+        {
+            _arrangedSubviews.CollectionChanged += ArrangedSubviewsChanged;
+            Initialize();
         }
 
         public override void AwakeFromNib()
         {
-            Initialize();
+            foreach (var constraint in Constraints)
+            {
+                if (constraint.GetType().Name == "NSIBPrototypingLayoutConstraint")
+                {
+                    RemoveConstraint(constraint);
+                }
+            }
+
+            foreach (var view in Subviews)
+                AddArrangedSubview(view);
+        }
+
+        public override void PrepareForInterfaceBuilder()
+        {
+            base.PrepareForInterfaceBuilder();
+
+            foreach (var view in Subviews)
+                AddArrangedSubview(view);
         }
 
         private void Initialize(IEnumerable<UIView> arrangedSubviews = null)

--- a/TZStackView/StackView.cs
+++ b/TZStackView/StackView.cs
@@ -530,7 +530,10 @@ namespace TZStackView
                 totalCount++;
             }
 
-            totalSize += (totalCount - 1)*Spacing;
+            totalSize += (totalCount - 1) * Spacing;
+
+            if (totalSize <= 0)
+                totalSize = 1;
 
             var priority = 1000f;
             var countDownPriority = viewss.Count(v => !IsHidden(v)) > 1;

--- a/build.cake
+++ b/build.cake
@@ -50,6 +50,7 @@ Task("Package")
 	.Does(() => {
 	if (IsRunningOnWindows()) //pdbstr.exe and costura are not xplat currently
 		GitLink(sln.GetDirectory(), new GitLinkSettings {
+			RepositoryUrl = "https://github.com/Cheesebaron/TZStackView",
 			ArgumentCustomization = args => args.Append("-ignore Sample")
 		});
 


### PR DESCRIPTION
As described in #4 the designer does not like enums.

This PR:
- aligns the enum values with what UIKit provides for UIStackView.
- adds ctor with CGFrame and fixes for subview constraints in Designer

